### PR TITLE
Day06

### DIFF
--- a/day06/generics/go.mod
+++ b/day06/generics/go.mod
@@ -1,0 +1,3 @@
+module example/generics
+
+go 1.24.2

--- a/day06/generics/main.go
+++ b/day06/generics/main.go
@@ -1,0 +1,79 @@
+package main
+
+import "fmt"
+
+type Number interface {
+	int64 | float64
+}
+
+// SumInts adds together the values of m.
+func SumInts(m map[string]int64) int64 {
+	var s int64
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+// SumFloats adds together the values of m.
+func SumFloats(m map[string]float64) float64 {
+	var s float64
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+// SumIntsOrFloats sums the values of map m. It supports both int64 and float64
+// as types for map values.
+func SumIntsOrFloats[K comparable, V int64 | float64](m map[K]V) V {
+	var s V
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+// SumNumbers sums the values of map m. It supports both integers
+// and floats as map values.
+func SumNumbers[K comparable, V Number](m map[K]V) V {
+	var s V
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+func main() {
+	// Initialize a map for the integer values
+	ints := map[string]int64{
+		"first":  34,
+		"second": 12,
+	}
+
+	// Initialize a map for the float values
+	floats := map[string]float64{
+		"first":  35.98,
+		"second": 26.99,
+	}
+
+	fmt.Printf("Non-Generic Sums: %v and %v\n",
+		SumInts(ints),
+		SumFloats(floats),
+	)
+
+	fmt.Printf("Generic Sums: %v and %v\n",
+		SumIntsOrFloats[string, int64](ints),
+		SumIntsOrFloats[string, float64](floats),
+	)
+
+	fmt.Printf("Generic Sums, type parameters inferred: %v and %v\n",
+		SumIntsOrFloats(ints),
+		SumIntsOrFloats(floats),
+	)
+
+	fmt.Printf("Generic Sums with Constraint: %v and %v\n",
+		SumNumbers(ints),
+		SumNumbers(floats),
+	)
+}


### PR DESCRIPTION
This pull request introduces a new module for generics in Go, demonstrating various ways to sum values in a map using both non-generic and generic functions. The most important changes include the creation of a new module, the implementation of specific functions for summing integers and floats, and the addition of generic functions to handle both types.

New module setup:

* [`day06/generics/go.mod`](diffhunk://#diff-2f929ec5aec3f5ac4f88f1c6b49056ea739bfba40a008cb5f638d4280c10d5f4R1-R3): Created a new Go module named `example/generics` and specified the Go version.

Implementation of summing functions:

* [`day06/generics/main.go`](diffhunk://#diff-782eef4ca6942c2309d34de815bea16e626c793e9b2c00c786607ff5e8b5f49cR1-R79): Added specific functions `SumInts` and `SumFloats` to sum integer and float values in a map, respectively.
* [`day06/generics/main.go`](diffhunk://#diff-782eef4ca6942c2309d34de815bea16e626c793e9b2c00c786607ff5e8b5f49cR1-R79): Introduced generic functions `SumIntsOrFloats` and `SumNumbers` to sum values in a map, supporting both integers and floats.
* [`day06/generics/main.go`](diffhunk://#diff-782eef4ca6942c2309d34de815bea16e626c793e9b2c00c786607ff5e8b5f49cR1-R79): Included a `main` function to demonstrate the usage of both non-generic and generic summing functions with example maps.