### PR TITLE
Day09

### DIFF
--- a/day09/go.mod
+++ b/day09/go.mod
@@ -1,0 +1,5 @@
+module day09
+
+go 1.24.2
+
+require golang.org/x/text v0.23.0

--- a/day09/go.sum
+++ b/day09/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=

--- a/day09/main.go
+++ b/day09/main.go
@@ -1,0 +1,24 @@
+// This program takes language tags as command-line
+// arguments and parses them.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/text/language"
+)
+
+func main() {
+	for _, arg := range os.Args[1:] {
+		tag, err := language.Parse(arg)
+		if err != nil {
+			fmt.Printf("%s: error: %v\n", arg, err)
+		} else if tag == language.Und {
+			fmt.Printf("%s: undefined\n", arg)
+		} else {
+			fmt.Printf("%s: tag %s\n", arg, tag)
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new Go module for parsing language tags from command-line arguments. The changes include the addition of a `go.mod` file and a new main program file.

### Go module setup:

* [`day09/go.mod`](diffhunk://#diff-8be8b9973655ed66ca2cf65fee0accb6a46b368ba39006b8e1c1766183ef99f8R1-R5): Created a new module `day09` and specified the Go version as 1.24.2. Added a dependency on `golang.org/x/text` version 0.23.0.

### Main program implementation:

* [`day09/main.go`](diffhunk://#diff-0c9d155ab408ba252fb85e5851e26523c6bfa75ffcd27b61e445d16396517daaR1-R24): Added a main program that imports necessary packages, iterates over command-line arguments, parses each as a language tag, and prints the result or an error message.